### PR TITLE
アスペクト比の変更機能を作成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 server/storage/*.mp4
+.vscode

--- a/client/client.py
+++ b/client/client.py
@@ -72,6 +72,28 @@ def get_resolution_choice():
         except ValueError:
             print("正しい数字を入力してください")
 
+def get_aspect_ratio_choice():
+    aspect_ratio_choices = {
+        # key : (aspect_ratio, description)  
+        1: ('4:3', '昔の映像などに使用'),
+        2: ('16:9', 'テレビ・配信動画用')
+    }
+    print('変更可能なアスペクト比リスト')
+    for choise, (aspect_ratio, description) in aspect_ratio_choices.items():
+        print(f'{choise}. {aspect_ratio} {description}')
+    print('------------------------')
+
+    while True:
+        try:
+            user_choise = int(input("変更したいアスペクト比を選択してください: ")) 
+            if user_choise in aspect_ratio_choices:
+                return aspect_ratio_choices[user_choise][0]
+            else:
+                print('リストの中の数字から選択してください')
+        
+        except Exception as e:
+            print(f'エラー：{str(e)}')
+
 def main():
     with open('config.json', 'r', encoding='utf-8') as f:
         config = json.load(f)
@@ -107,8 +129,12 @@ def main():
                     'resolution': chosen_resolution
                 }
             case 3:
+                chosen_aspect_ratio = get_aspect_ratio_choice()
                 #動画のアスペクト比の変更
-                req_params = {'action': action}
+                req_params = {
+                    'action': action,
+                    'aspect_ratio': chosen_aspect_ratio 
+                }
             case 4:
                 #動画をオーディオに変換
                 req_params = {'action': action}

--- a/server/server.py
+++ b/server/server.py
@@ -123,9 +123,10 @@ def handle_aspect_change(input_filename, dir_path, req_data):
 
     print(f"FFMPEG実行中: {' '.join(ffmpeg_cmd)}")
 
-    result = subprocess.run(ffmpeg_cmd, capture_output=True, text=True)
+    result = subprocess.run(ffmpeg_cmd, capture_output=True, text=False)
     if result.returncode != 0:
         raise Exception(f"FFMPEG エラー: {result.stderr}")
+
     return output_filename
 
 

--- a/server/server.py
+++ b/server/server.py
@@ -148,7 +148,7 @@ def main():
                     
                     case 3:
                         try:
-                            processed_filename = handle_resolution_change(filename, dir_path, req_data)
+                            processed_filename = handle_aspect_change(filename, dir_path, req_data)
                             print(f'解像度変更完了: {processed_filename}')
                         except Exception as process_err:
                             error = ErrorInfo('1004', f'動画のアスペクト比変更中のエラー: {str(process_err)}', 'アップロード動画を確認し再度アップロードおよび操作をしてください、解決しない場合は管理者にお問い合わせください。')

--- a/server/server.py
+++ b/server/server.py
@@ -161,9 +161,6 @@ def main():
 
             filename = f'{uuid.uuid4().hex}.{mediatype}'
 
-            # TODO : delete print
-            print(f'req is {req_params}')
-
             # ファイルサイズが0の場合はエラーとして扱う
             if file_size <= 0:
                 raise Exception('ファイルサイズが無効です')

--- a/server/server.py
+++ b/server/server.py
@@ -117,7 +117,7 @@ def handle_aspect_change(input_filename, dir_path, req_data):
         '-aspect', chosen_aspect_ratio,  # アスペクト比を設定
         '-c:v', 'libx264',              # 動画コーデック
         '-c:a', 'copy',                 # 音声はコピー
-        '-preset', 'fast',
+        '-preset', 'ultrafast', 
         output_path
     ]
 

--- a/server/server.py
+++ b/server/server.py
@@ -53,6 +53,33 @@ def handle_resolution_change(input_filename, dir_path, req_data):
         raise Exception(f"FFMPEG エラー: {result.stderr}")
     return output_filename
 
+def handle_aspect_change(input_filename, dir_path, req_data):
+    chosen_aspect_ratio = req_data.get('aspect_ratio', 0)
+
+    input_path = os.path.join(dir_path, input_filename)
+    base_name = input_filename.split('.')[0]
+    output_filename = f"{base_name}_{chosen_aspect_ratio}.mp4"
+    output_path = os.path.join(dir_path, output_filename)
+
+    ffmpeg_cmd = [
+        'ffmpeg',
+        '-y',
+        '-i', input_path,
+        '-aspect', chosen_aspect_ratio,  # アスペクト比を設定
+        '-c:v', 'libx264',              # 動画コーデック
+        '-c:a', 'copy',                 # 音声はコピー
+        '-preset', 'fast',
+        output_path
+    ]
+
+    print(f"FFMPEG実行中: {' '.join(ffmpeg_cmd)}")
+
+    result = subprocess.run(ffmpeg_cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise Exception(f"FFMPEG エラー: {result.stderr}")
+    return output_filename
+
+
 def main():
     with open('config.json', 'r', encoding='utf-8') as f:
         config = json.load(f)
@@ -117,6 +144,14 @@ def main():
 
                         except Exception as process_err:
                             error = ErrorInfo('1003', f'動画処理中のエラー: {str(process_err)}', 'FFMPEGが正しくインストールされているか確認してください。')
+                            print(f"処理エラー: {str(process_err)}")
+                    
+                    case 3:
+                        try:
+                            processed_filename = handle_resolution_change(filename, dir_path, req_data)
+                            print(f'解像度変更完了: {processed_filename}')
+                        except Exception as process_err:
+                            error = ErrorInfo('1004', f'動画のアスペクト比変更中のエラー: {str(process_err)}', 'アップロード動画を確認し再度アップロードおよび操作をしてください、解決しない場合は管理者にお問い合わせください。')
                             print(f"処理エラー: {str(process_err)}")
 
         except Exception as e:

--- a/server/server.py
+++ b/server/server.py
@@ -127,7 +127,7 @@ def handle_aspect_change(input_filename, dir_path, req_data):
     if result.returncode != 0:
         raise Exception(f"FFMPEG エラー: {result.stderr}")
 
-    return output_filename
+    return output_filename, output_path
 
 
 def main():
@@ -199,8 +199,9 @@ def main():
 
                     case 3:
                         try:
-                            processed_filename = handle_aspect_change(filename, dir_path, req_data)
+                            processed_filename, output_path = handle_aspect_change(filename, dir_path, req_data)
                             print(f'アスペクト比変更完了: {processed_filename}')
+                            send_response(connection, output_path, stream_rate)
                         except Exception as process_err:
                             error = ErrorInfo('1004', f'動画のアスペクト比変更中のエラー: {str(process_err)}', 'アップロード動画を確認し再度アップロードおよび操作をしてください、解決しない場合は管理者にお問い合わせください。')
                             print(f"処理エラー: {str(process_err)}")

--- a/server/server.py
+++ b/server/server.py
@@ -84,6 +84,9 @@ def main():
 
             filename = f'{uuid.uuid4().hex}.{mediatype}'
 
+            # TODO : delete print
+            print(f'req is {req_params}')
+
             # ファイルサイズが0の場合はエラーとして扱う
             if file_size <= 0:
                 raise Exception('ファイルサイズが無効です')


### PR DESCRIPTION
# issue
https://github.com/teamdev-online-chat-messenger-b2/videoCompressor/issues/4

# 実行検証

(1) 16:9の動画を、4:3に変更

- input動画
<img width="773" height="426" alt="image" src="https://github.com/user-attachments/assets/cbb78e5c-f5f6-47b5-b107-429ca8eec387" />

- output動画
<img width="768" height="561" alt="image" src="https://github.com/user-attachments/assets/548a3c21-9943-4022-9f56-f76ad1fd55d6" />



- client
```
[~/recursion/videoCompressor]+[feature/change_aspect]$ python client/client.py
サーバーに接続します。
処理対象の動画ファイルパスを入力してください
input.mp4
=== 動画処理メニュー ===
1 動画ファイルの圧縮
2 動画の解像度の変更
3 動画のアスペクト比の変更
4 動画をオーディオに変換
5 時間範囲での GIF と WEBM の作成
========================
メニューから処理を選択してください: 3
変更可能なアスペクト比リスト
1. 4:3 昔の映像などに使用
2. 16:9 テレビ・配信動画用
------------------------
変更したいアスペクト比を選択してください: 1
19処理成功！
処理後の動画を保存するファイル名を入力してください
^R
4_3_video.mp4
処理後の動画を保存完了！
ソケットを閉じます
```
- server

```

[~/recursion/videoCompressor]+[feature/change_aspect]$ python server/server.py
サーバーが起動します。クライアントからの接続を待ちます。
クライアントから接続します。。
req is {"action": 3, "aspect_ratio": "4:3"}
ファイルのアップロードが完了しました。
受信したアクション: 3
FFMPEG実行中: ffmpeg -y -i /Users/{user}/recursion/videoCompressor/server/storage/bcfaa17e59b14eb2a325c04d1134a284.mp4 -aspect 4:3 -c:v libx264 -c:a copy -preset ultrafast /Users/{user}/recursion/videoCompressor/server/storage/bcfaa17e59b14eb2a325c04d1134a284_4:3.mp4
アスペクト比変更完了: bcfaa17e59b14eb2a325c04d1134a284_4:3.mp4
処理済みファイル（21582416バイト）を送信中
処理済みファイルの送信完了
コネクションを閉じます
```

(2) 4:3の動画を、16:9に変更

- input動画
(1)のoutput動画を使用

- output動画
<img width="801" height="449" alt="image" src="https://github.com/user-attachments/assets/d986ec69-9cef-4c3a-b01b-bdbf6730b97a" />



-client
```
[~/recursion/videoCompressor]+[feature/change_aspect]$ python client/client.py
サーバーに接続します。
処理対象の動画ファイルパスを入力してください
4_3_video.mp4
=== 動画処理メニュー ===
1 動画ファイルの圧縮
2 動画の解像度の変更
3 動画のアスペクト比の変更
4 動画をオーディオに変換
5 時間範囲での GIF と WEBM の作成
========================
メニューから処理を選択してください: 3
変更可能なアスペクト比リスト
1. 4:3 昔の映像などに使用
2. 16:9 テレビ・配信動画用
------------------------
変更したいアスペクト比を選択してください: 2
処理成功！
処理後の動画を保存するファイル名を入力してください
16_9_video.mp4
処理後の動画を保存完了！
ソケットを閉じます

```

-server
```
[~/recursion/videoCompressor]+[feature/change_aspect]$ python server/server.py
クライアントから接続します。。
req is {"action": 3, "aspect_ratio": "16:9"}
ファイルのアップロードが完了しました。
受信したアクション: 3
FFMPEG実行中: ffmpeg -y -i /Users/{user}/recursion/videoCompressor/server/storage/4a4043f5ee5d4c729b5608589b3f48b2.mp4 -aspect 16:9 -c:v libx264 -c:a copy -preset ultrafast /Users/{user}/recursion/videoCompressor/server/storage/4a4043f5ee5d4c729b5608589b3f48b2_16:9.mp4
アスペクト比変更完了: 4a4043f5ee5d4c729b5608589b3f48b2_16:9.mp4
処理済みファイル（21020342バイト）を送信中
処理済みファイルの送信完了
コネクションを閉じます
```