### PR TITLE
Electron.jsクライアントからサーバーに対して処理を依頼しダウンロードできる機能を追加

### DIFF
--- a/client_desktop_app/src/index.html
+++ b/client_desktop_app/src/index.html
@@ -1,172 +1,194 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>動画変換サービス</title>
-    <link rel="stylesheet" href="style.css" />
-    <script src="renderer.js" defer></script>
-  </head>
-  <body>
-    <div class="container">
-      <header>
-        <h1>🎬 動画変換サービス</h1>
-        <p>動画をアップロードして、お好みの形式に変換しましょう</p>
-      </header>
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>動画変換サービス</title>
+        <link rel="stylesheet" href="style.css" />
+        <script src="renderer.js" defer></script>
+    </head>
+    <body>
+        <div class="container">
+            <header>
+                <h1>🎬 動画変換サービス</h1>
+                <p>動画をアップロードして、お好みの形式に変換しましょう</p>
+            </header>
 
-      <main>
-        <!-- ファイルアップロードセクション -->
-        <section class="upload-section">
-          <h2>1. 動画をアップロード</h2>
-          <div class="upload-area" id="uploadArea">
-            <div class="upload-content">
-              <div class="upload-icon">📁</div>
-              <p>クリックして動画を選択</p>
-              <p class="file-types">対応形式: MP4</p>
-            </div>
-            <input type="file" id="videoFile" accept="video/*" hidden />
-          </div>
-          <div id="fileInfo" class="file-info hidden">
-            <h3>選択されたファイル:</h3>
-            <p id="fileName"></p>
-          </div>
-        </section>
+            <main>
+                <!-- ファイルアップロードセクション -->
+                <section class="upload-section">
+                    <h2>1. 動画をアップロード</h2>
+                    <div class="upload-area" id="uploadArea">
+                        <div class="upload-content">
+                            <div class="upload-icon">📁</div>
+                            <p>クリックして動画を選択</p>
+                            <p class="file-types">対応形式: MP4</p>
+                        </div>
+                        <!-- <input
+                            type="file"
+                            id="videoFile"
+                            accept="video/*"
+                            hidden
+                        /> -->
+                    </div>
+                    <div id="fileInfo" class="file-info hidden">
+                        <h3>選択されたファイル:</h3>
+                        <p id="fileName"></p>
+                    </div>
+                </section>
 
-        <!-- 操作選択セクション -->
-        <section class="operation-section">
-          <h2>2. 動画操作を選択</h2>
-          <div class="operation-grid">
-            <div class="operation-card" data-operation="compress">
-              <div class="operation-icon">🗜️</div>
-              <h3>圧縮</h3>
-              <p>最適な圧縮でファイルサイズを削減</p>
-            </div>
-            <div class="operation-card" data-operation="resolution">
-              <div class="operation-icon">📐</div>
-              <h3>解像度変更</h3>
-              <p>動画の解像度を変更</p>
-            </div>
-            <div class="operation-card" data-operation="aspect">
-              <div class="operation-icon">📏</div>
-              <h3>アスペクト比変更</h3>
-              <p>動画のアスペクト比を変更</p>
-            </div>
-            <div class="operation-card" data-operation="audio">
-              <div class="operation-icon">🎵</div>
-              <h3>オーディオ変換</h3>
-              <p>動画を音声ファイルに変換</p>
-            </div>
-            <div class="operation-card" data-operation="gif">
-              <div class="operation-icon">🎞️</div>
-              <h3>GIF/WEBM変換</h3>
-              <p>動画をGIFまたはWEBMに変換</p>
-            </div>
-          </div>
-        </section>
+                <!-- 操作選択セクション -->
+                <section class="operation-section">
+                    <h2>2. 動画操作を選択</h2>
+                    <div class="operation-grid">
+                        <div class="operation-card" data-operation="compress">
+                            <div class="operation-icon">🗜️</div>
+                            <h3>圧縮</h3>
+                            <p>最適な圧縮でファイルサイズを削減</p>
+                        </div>
+                        <div class="operation-card" data-operation="resolution">
+                            <div class="operation-icon">📐</div>
+                            <h3>解像度変更</h3>
+                            <p>動画の解像度を変更</p>
+                        </div>
+                        <div class="operation-card" data-operation="aspect">
+                            <div class="operation-icon">📏</div>
+                            <h3>アスペクト比変更</h3>
+                            <p>動画のアスペクト比を変更</p>
+                        </div>
+                        <div class="operation-card" data-operation="audio">
+                            <div class="operation-icon">🎵</div>
+                            <h3>オーディオ変換</h3>
+                            <p>動画を音声ファイルに変換</p>
+                        </div>
+                        <div class="operation-card" data-operation="gif">
+                            <div class="operation-icon">🎞️</div>
+                            <h3>GIF/WEBM変換</h3>
+                            <p>動画をGIFまたはWEBMに変換</p>
+                        </div>
+                    </div>
+                </section>
 
-        <!-- 設定セクション -->
-        <section class="settings-section hidden" id="settingsSection">
-          <h2>3. 操作設定</h2>
-          <div class="settings-content">
-            <!-- 解像度設定 -->
-            <div class="setting-group hidden" id="resolutionSettings">
-              <h3>解像度設定</h3>
-              <div class="input-group">
-                <label for="resolutionSelect">解像度:</label>
-                <select id="resolutionSelect">
-                  <option value="480p">480p (854×480)</option>
-                  <option value="720p">720p (1280×720)</option>
-                  <option value="1080p" selected>1080p (1920×1080)</option>
-                  <option value="1440p">1440p (2560×1440)</option>
-                  <option value="4K">4K (3840×2160)</option>
-                </select>
-              </div>
-            </div>
+                <!-- 設定セクション -->
+                <section class="settings-section hidden" id="settingsSection">
+                    <h2>3. 操作設定</h2>
+                    <div class="settings-content">
+                        <!-- 解像度設定 -->
+                        <div
+                            class="setting-group hidden"
+                            id="resolutionSettings"
+                        >
+                            <h3>解像度設定</h3>
+                            <div class="input-group">
+                                <label for="resolutionSelect">解像度:</label>
+                                <select id="resolutionSelect">
+                                    <option value="480p">480p (854×480)</option>
+                                    <option value="720p">
+                                        720p (1280×720)
+                                    </option>
+                                    <option value="1080p" selected>
+                                        1080p (1920×1080)
+                                    </option>
+                                    <option value="1440p">
+                                        1440p (2560×1440)
+                                    </option>
+                                    <option value="4K">4K (3840×2160)</option>
+                                </select>
+                            </div>
+                        </div>
 
-            <!-- アスペクト比設定 -->
-            <div class="setting-group hidden" id="aspectSettings">
-              <h3>アスペクト比設定</h3>
-              <div class="input-group">
-                <label for="aspectRatio">アスペクト比:</label>
-                <select id="aspectRatio">
-                  <option value="16:9">16:9 (ワイドスクリーン)</option>
-                  <option value="4:3">4:3 (標準)</option>
-                </select>
-              </div>
-            </div>
+                        <!-- アスペクト比設定 -->
+                        <div class="setting-group hidden" id="aspectSettings">
+                            <h3>アスペクト比設定</h3>
+                            <div class="input-group">
+                                <label for="aspectRatio">アスペクト比:</label>
+                                <select id="aspectRatio">
+                                    <option value="16:9">
+                                        16:9 (ワイドスクリーン)
+                                    </option>
+                                    <option value="4:3">4:3 (標準)</option>
+                                </select>
+                            </div>
+                        </div>
 
-            <!-- GIF/WEBM設定 -->
-            <div class="setting-group hidden" id="gifSettings">
-              <h3>GIF/WEBM設定</h3>
-              <div class="input-group">
-                <label for="startTime">開始時間 (HH:MM:SS):</label>
-                <input
-                  type="text"
-                  id="startTime"
-                  placeholder="00:00:00"
-                  pattern="^([0-9]{1,2}:)?[0-5]?[0-9]:[0-5][0-9]$"
-                />
-              </div>
-              <div class="input-group">
-                <label for="endTime">終了時間 (HH:MM:SS):</label>
-                <input
-                  type="text"
-                  id="endTime"
-                  placeholder="00:00:10"
-                  pattern="^([0-9]{1,2}:)?[0-5]?[0-9]:[0-5][0-9]$"
-                />
-              </div>
-              <div class="input-group">
-                <label for="outputFormat">出力形式:</label>
-                <select id="outputFormat">
-                  <option value="gif">GIF</option>
-                  <option value="webm">WEBM</option>
-                </select>
-              </div>
-            </div>
+                        <!-- GIF/WEBM設定 -->
+                        <div class="setting-group hidden" id="gifSettings">
+                            <h3>GIF/WEBM設定</h3>
+                            <div class="input-group">
+                                <label for="startTime"
+                                    >開始時間 (HH:MM:SS):</label
+                                >
+                                <input
+                                    type="text"
+                                    id="startTime"
+                                    placeholder="00:00:00"
+                                    pattern="^([0-9]{1,2}:)?[0-5]?[0-9]:[0-5][0-9]$"
+                                />
+                            </div>
+                            <div class="input-group">
+                                <label for="endTime"
+                                    >終了時間 (HH:MM:SS):</label
+                                >
+                                <input
+                                    type="text"
+                                    id="endTime"
+                                    placeholder="00:00:10"
+                                    pattern="^([0-9]{1,2}:)?[0-5]?[0-9]:[0-5][0-9]$"
+                                />
+                            </div>
+                            <div class="input-group">
+                                <label for="outputFormat">出力形式:</label>
+                                <select id="outputFormat">
+                                    <option value="gif">GIF</option>
+                                    <option value="webm">WEBM</option>
+                                </select>
+                            </div>
+                        </div>
 
-            <!-- ファイル名設定 -->
-            <div class="setting-group">
-              <h3>出力ファイル名</h3>
-              <div class="input-group">
-                <label for="outputFileName">ファイル名:</label>
-                <input
-                  type="text"
-                  id="outputFileName"
-                  placeholder="変換後の動画"
-                />
-              </div>
-            </div>
-          </div>
-        </section>
+                        <!-- ファイル名設定 -->
+                        <div class="setting-group hidden" id="outputSettings">
+                            <h3>出力ファイル名</h3>
+                            <div class="input-group">
+                                <label for="outputFileName"
+                                    >拡張子を除いたファイル名:</label
+                                >
+                                <input
+                                    type="text"
+                                    id="outputFileName"
+                                    placeholder="変換後の動画"
+                                />
+                            </div>
+                        </div>
+                    </div>
+                </section>
 
-        <!-- 実行ボタン -->
-        <section class="execute-section">
-          <button id="executeBtn" class="execute-btn" disabled>
-            🚀 変換を実行
-          </button>
-        </section>
+                <!-- 実行ボタン -->
+                <section class="execute-section">
+                    <button id="executeBtn" class="execute-btn" disabled>
+                        🚀 変換を実行
+                    </button>
+                </section>
 
-        <!-- 進捗表示 -->
-        <section class="progress-section hidden" id="progressSection">
-          <h2>変換中...</h2>
-          <div class="progress-bar">
-            <div class="progress-fill" id="progressFill"></div>
-          </div>
-          <p id="progressText">処理を開始しています...</p>
-        </section>
+                <!-- 進捗表示 -->
+                <section class="progress-section hidden" id="progressSection">
+                    <h2>変換中...</h2>
+                    <div class="progress-bar">
+                        <div class="progress-fill" id="progressFill"></div>
+                    </div>
+                    <p id="progressText">処理を開始しています...</p>
+                </section>
 
-        <!-- 結果表示 -->
-        <section class="result-section hidden" id="resultSection">
-          <h2>✅ 変換完了!</h2>
-          <div class="result-content">
-            <p id="resultMessage"></p>
-            <button id="downloadBtn" class="download-btn">
-              📥 ダウンロード
-            </button>
-          </div>
-        </section>
-      </main>
-    </div>
-  </body>
+                <!-- 結果表示 -->
+                <section class="result-section hidden" id="resultSection">
+                    <h2>✅ 変換完了!</h2>
+                    <div class="result-content">
+                        <p id="resultMessage"></p>
+                        <button id="downloadBtn" class="download-btn">
+                            📥 ダウンロード
+                        </button>
+                    </div>
+                </section>
+            </main>
+        </div>
+    </body>
 </html>

--- a/client_desktop_app/src/index.html
+++ b/client_desktop_app/src/index.html
@@ -24,12 +24,6 @@
                             <p>クリックして動画を選択</p>
                             <p class="file-types">対応形式: MP4</p>
                         </div>
-                        <!-- <input
-                            type="file"
-                            id="videoFile"
-                            accept="video/*"
-                            hidden
-                        /> -->
                     </div>
                     <div id="fileInfo" class="file-info hidden">
                         <h3>選択されたファイル:</h3>

--- a/client_desktop_app/src/main.ts
+++ b/client_desktop_app/src/main.ts
@@ -1,21 +1,128 @@
-import { app, BrowserWindow } from 'electron';
-import * as path from 'path';
+import {
+  app,
+  BrowserWindow,
+  ipcMain,
+  dialog,
+  OpenDialogReturnValue,
+} from "electron";
+import { stat } from "fs/promises";
+import * as path from "path";
+import * as fs from "fs";
+import * as net from "net";
+
+interface ProcessingRequest {
+  filePath: string;
+  requestParams: {
+    action: number;
+    resolution?: string;
+    aspect_ratio?: string;
+    startseconds?: number;
+    endseconds?: number;
+    extension?: string;
+  };
+}
+
+interface ServerConfig {
+  server_address: string;
+  server_port: number;
+  stream_rate: number;
+}
 
 function createWindow() {
   const win = new BrowserWindow({
     width: 800,
     height: 600,
     webPreferences: {
-      preload: path.join(app.getAppPath(), 'preload.js')
+      preload: path.join(app.getAppPath(), "preload.js"),
+      nodeIntegration: true,
+      contextIsolation: true,
     },
   });
 
-  win.loadFile(path.join(__dirname, 'index.html'));
-  win.webContents.openDevTools();  // 開発時のみ
+  win.loadFile(path.join(__dirname, "index.html"));
+  win.webContents.openDevTools(); // 開発時のみ
 }
+
+ipcMain.handle("open-video-dialog", async () => {
+  // eslint-disable-next-line @typescript-eslint/await-thenable
+  const result = await dialog.showOpenDialog({
+    properties: ["openFile"],
+    filters: [
+      {
+        name: "Video Files",
+        extensions: ["mp4"],
+      },
+    ],
+    title: "Select a video file",
+  });
+
+  console.log("Dialog result:", result);
+  console.log("Result type:", typeof result);
+  console.log("Has canceled property:", "canceled" in result);
+
+  // @ts-ignore - Suppress TypeScript error
+  if (!result.canceled && result.filePaths.length > 0) {
+    // @ts-ignore - Suppress TypeScript error
+    return result.filePaths[0];
+  }
+  return null;
+});
+
+ipcMain.handle("get-file-stats", async (event, filePath: string) => {
+  try {
+    const stats = await stat(filePath);
+    return {
+      size: stats.size,
+      isFile: stats.isFile(),
+    };
+  } catch (error) {
+    console.error("ファイル情報取得中のエラー：", error);
+    return null;
+  }
+});
+
+function loadClientConfig(): ServerConfig {
+  try {
+    const configPath = path.join(__dirname, "..", "..", "config.json");
+
+    const configData = fs.readFileSync(configPath, "utf-8");
+    const config = JSON.parse(configData);
+
+    console.log("コンフィグ：", config);
+
+    return {
+      server_address: config.server_address,
+      server_port: config.server_port,
+      stream_rate: config.stream_rate,
+    };
+  } catch (error) {
+    throw error;
+  }
+}
+
+ipcMain.handle(
+  "process-video-request",
+  async (event, request: ProcessingRequest) => {
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 20000));
+
+      const testResponse = {
+        status: "success",
+        message: "Communication test successful!",
+        filename: "test_output.mp4",
+        originalFile: request.filePath,
+        action: request.requestParams.action,
+      };
+
+      return testResponse;
+    } catch (error) {
+      throw error;
+    }
+  },
+);
 
 app.whenReady().then(createWindow);
 
-app.on('window-all-closed', () => {
-  if (process.platform !== 'darwin') app.quit();
+app.on("window-all-closed", () => {
+  if (process.platform !== "darwin") app.quit();
 });

--- a/client_desktop_app/src/main.ts
+++ b/client_desktop_app/src/main.ts
@@ -31,8 +31,6 @@ function createWindow() {
     height: 600,
     webPreferences: {
       preload: path.join(app.getAppPath(), "preload.js"),
-      nodeIntegration: true,
-      contextIsolation: true,
     },
   });
 

--- a/client_desktop_app/src/main.ts
+++ b/client_desktop_app/src/main.ts
@@ -1,10 +1,4 @@
-import {
-  app,
-  BrowserWindow,
-  ipcMain,
-  dialog,
-  OpenDialogReturnValue,
-} from "electron";
+import { app, BrowserWindow, ipcMain, dialog } from "electron";
 import { stat } from "fs/promises";
 import * as path from "path";
 import * as fs from "fs";
@@ -56,10 +50,6 @@ ipcMain.handle("open-video-dialog", async () => {
     title: "Select a video file",
   });
 
-  console.log("Dialog result:", result);
-  console.log("Result type:", typeof result);
-  console.log("Has canceled property:", "canceled" in result);
-
   // @ts-ignore - Suppress TypeScript error
   if (!result.canceled && result.filePaths.length > 0) {
     // @ts-ignore - Suppress TypeScript error
@@ -81,14 +71,70 @@ ipcMain.handle("get-file-stats", async (event, filePath: string) => {
   }
 });
 
+ipcMain.handle(
+  "process-video-request",
+  async (event, request: ProcessingRequest) => {
+    try {
+      const result = await processVideoRequest(request);
+
+      return result;
+    } catch (error) {
+      throw error;
+    }
+  },
+);
+
+ipcMain.handle(
+  "download-file",
+  async (
+    event,
+    fileData: { filename: string; fileData: any; fileExtension: string },
+  ) => {
+    try {
+      const result = await dialog.showSaveDialog({
+        defaultPath: fileData.filename,
+        filters: [
+          { name: "Video Files", extensions: [fileData.fileExtension] },
+          { name: "All Files", extensions: ["*"] },
+        ],
+        title: "Save processed video",
+      });
+
+      // @ts-ignore - Suppress TypeScript error
+      if (!result.canceled && result.filePath) {
+        let bufferToWrite;
+
+        if (Array.isArray(fileData.fileData)) {
+          bufferToWrite = Buffer.from(fileData.fileData);
+        } else if (fileData.fileData instanceof Uint8Array) {
+          bufferToWrite = Buffer.from(fileData.fileData);
+        } else if (Buffer.isBuffer(fileData.fileData)) {
+          bufferToWrite = fileData.fileData;
+        } else {
+          bufferToWrite = Buffer.from(fileData.fileData);
+        }
+
+        // @ts-ignore - Suppress TypeScript error
+        fs.writeFileSync(result.filePath, bufferToWrite);
+        // @ts-ignore - Suppress TypeScript error
+        return { success: true, path: result.filePath };
+      }
+
+      return { success: false };
+    } catch (error) {
+      console.error("=== DOWNLOAD ERROR ===");
+      console.error("Error details:", error);
+      throw error;
+    }
+  },
+);
+
 function loadClientConfig(): ServerConfig {
   try {
     const configPath = path.join(__dirname, "..", "..", "config.json");
 
     const configData = fs.readFileSync(configPath, "utf-8");
     const config = JSON.parse(configData);
-
-    console.log("コンフィグ：", config);
 
     return {
       server_address: config.server_address,
@@ -100,29 +146,232 @@ function loadClientConfig(): ServerConfig {
   }
 }
 
-ipcMain.handle(
-  "process-video-request",
-  async (event, request: ProcessingRequest) => {
+function connectToServer(config: ServerConfig): Promise<net.Socket> {
+  return new Promise((resolve, reject) => {
+    const socket = new net.Socket();
+
+    socket.connect(config.server_port, config.server_address, () => {
+      resolve(socket);
+    });
+
+    socket.on("error", (error) => {
+      console.error("Socket error:", error);
+      reject(error);
+    });
+
+    socket.setTimeout(30000);
+    socket.on("timeout", () => {
+      socket.destroy();
+      reject(new Error("Connection timeout"));
+    });
+  });
+}
+
+function createRequestHeader(
+  jsonSize: number,
+  mediatypeSize: number,
+  payloadSize: number,
+): Buffer {
+  const header = Buffer.alloc(8);
+  header.writeUIntBE(jsonSize, 0, 2);
+  header.writeUIntBE(mediatypeSize, 2, 1);
+  header.writeUIntBE(payloadSize, 3, 5);
+  return header;
+}
+
+async function sendFileData(
+  socket: net.Socket,
+  filePath: string,
+  requestParams: any,
+  config: ServerConfig,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
     try {
-      await new Promise((resolve) => setTimeout(resolve, 20000));
+      const mediatype = path.extname(filePath).substring(1);
+      const stats = fs.statSync(filePath);
+      const fileSize = stats.size;
 
-      const testResponse = {
-        status: "success",
-        message: "Communication test successful!",
-        filename: "test_output.mp4",
-        originalFile: request.filePath,
-        action: request.requestParams.action,
-      };
+      const reqParamsJson = JSON.stringify(requestParams);
+      const reqParamsSize = Buffer.byteLength(reqParamsJson, "utf8");
+      const mediatypeSize = Buffer.byteLength(mediatype, "utf8");
 
-      return testResponse;
+      const header = createRequestHeader(
+        reqParamsSize,
+        mediatypeSize,
+        fileSize,
+      );
+      socket.write(header);
+
+      socket.write(reqParamsJson, "utf8");
+
+      socket.write(mediatype, "utf8");
+
+      const fileStream = fs.createReadStream(filePath, {
+        highWaterMark: config.stream_rate,
+      });
+
+      fileStream.on("data", (chunk) => {
+        socket.write(chunk);
+      });
+
+      fileStream.on("end", () => {
+        resolve();
+      });
+
+      fileStream.on("error", (error) => {
+        console.error("動画データ送信中のエラー：", error);
+        reject(error);
+      });
     } catch (error) {
-      throw error;
+      console.error("動画データ送信中のエラー：", error);
+      reject(error);
     }
-  },
-);
+  });
+}
+
+async function receiveResponse(socket: net.Socket): Promise<any> {
+  return new Promise((resolve, reject) => {
+    let buffer = Buffer.alloc(0);
+    let headerReceived = false;
+    let responseCode: number;
+    let dataSize: number;
+    let totalDataReceived = 0;
+    let successJson: any = null;
+    let fileData = Buffer.alloc(0);
+    let expectingFileData = false;
+
+    socket.on("data", (chunk: Buffer) => {
+      buffer = Buffer.concat([buffer, chunk]);
+
+      try {
+        if (!headerReceived && buffer.length >= 1) {
+          responseCode = buffer.readUInt8(0);
+
+          if (responseCode === 0x00) {
+            if (buffer.length >= 5) {
+              dataSize = buffer.readUInt32BE(1);
+              if (buffer.length >= 5 + dataSize) {
+                const errorData = buffer.subarray(5, 5 + dataSize);
+                const errorText = errorData.toString("utf-8");
+                headerReceived = true;
+                resolve({ status: "error", error: errorText });
+                return;
+              }
+            }
+          } else {
+            if (buffer.length >= 5) {
+              dataSize = buffer.readUInt32BE(1);
+              if (buffer.length >= 5 + dataSize) {
+                const jsonData = buffer.subarray(5, 5 + dataSize);
+                successJson = JSON.parse(jsonData.toString("utf-8"));
+
+                buffer = buffer.subarray(5 + dataSize);
+                totalDataReceived = 0;
+                expectingFileData = true;
+                headerReceived = true;
+
+                if (buffer.length > 0) {
+                  fileData = Buffer.concat([fileData, buffer]);
+                  totalDataReceived += buffer.length;
+                  buffer = Buffer.alloc(0);
+                }
+
+                if (totalDataReceived >= successJson.file_size) {
+                  resolve({
+                    status: "success",
+                    filename: successJson.file_extension
+                      ? `output.${successJson.file_extension}`
+                      : "output.mp4",
+                    fileData: fileData.subarray(0, successJson.file_size),
+                    fileExtension: successJson.file_extension,
+                  });
+                }
+              }
+            }
+          }
+        } else if (headerReceived && expectingFileData) {
+          fileData = Buffer.concat([fileData, buffer]);
+          totalDataReceived += buffer.length;
+          buffer = Buffer.alloc(0);
+
+          if (totalDataReceived >= successJson.file_size) {
+            resolve({
+              status: "success",
+              filename: successJson.file_extension
+                ? `output.${successJson.file_extension}`
+                : "output.mp4",
+              fileData: fileData.subarray(0, successJson.file_size),
+              fileExtension: successJson.file_extension,
+            });
+          }
+        }
+      } catch (error) {
+        console.error("Error processing received data:", error);
+        reject(error);
+      }
+    });
+
+    socket.on("error", (error) => {
+      console.error("Socket error during receive:", error);
+      reject(error);
+    });
+
+    socket.on("close", () => {
+      if (!headerReceived) {
+        reject(
+          new Error("Connection closed before receiving complete response"),
+        );
+      }
+    });
+  });
+}
+
+async function processVideoRequest(request: ProcessingRequest): Promise<any> {
+  const config = loadClientConfig();
+
+  let socket: net.Socket | null = null;
+
+  try {
+    socket = await connectToServer(config);
+
+    await sendFileData(socket, request.filePath, request.requestParams, config);
+
+    const response = await receiveResponse(socket);
+
+    if (response.status === "error") {
+      throw new Error(response.error);
+    }
+
+    const userFileName =
+      (request.requestParams as any).outputFileName || "output";
+    const finalFileName = `${userFileName}.${response.fileExtension}`;
+
+    return {
+      status: "success",
+      message: "Video processing completed successfully!",
+      filename: finalFileName,
+      fileExtension: response.fileExtension,
+      fileData: Array.from(response.fileData),
+    };
+  } catch (error) {
+    console.error("=== ERROR PROCESSING VIDEO ===");
+    console.error("Error:", error);
+    throw error;
+  } finally {
+    if (socket) {
+      socket.destroy();
+    }
+  }
+}
 
 app.whenReady().then(createWindow);
 
 app.on("window-all-closed", () => {
   if (process.platform !== "darwin") app.quit();
+});
+
+app.on("activate", () => {
+  if (BrowserWindow.getAllWindows().length === 0) {
+    createWindow();
+  }
 });

--- a/client_desktop_app/src/preload.ts
+++ b/client_desktop_app/src/preload.ts
@@ -9,6 +9,7 @@ interface ElectronAPI {
   openVideoDialog: () => Promise<string | any>;
   getFileStats: (filePath: string) => Promise<FileStats | any>;
   processVideo: (filePath: string, params: any) => Promise<any>;
+  downloadFile: (fileData: any) => Promise<any>;
 }
 
 contextBridge.exposeInMainWorld("electronAPI", {
@@ -22,6 +23,14 @@ contextBridge.exposeInMainWorld("electronAPI", {
         requestParams: params,
       });
 
+      return result;
+    } catch (error) {
+      throw error;
+    }
+  },
+  downloadFile: async (fileData: any) => {
+    try {
+      const result = await ipcRenderer.invoke("download-file", fileData);
       return result;
     } catch (error) {
       throw error;

--- a/client_desktop_app/src/preload.ts
+++ b/client_desktop_app/src/preload.ts
@@ -1,0 +1,30 @@
+import { contextBridge, ipcRenderer } from "electron";
+
+interface FileStats {
+  size: number;
+  isFile: boolean;
+}
+
+interface ElectronAPI {
+  openVideoDialog: () => Promise<string | any>;
+  getFileStats: (filePath: string) => Promise<FileStats | any>;
+  processVideo: (filePath: string, params: any) => Promise<any>;
+}
+
+contextBridge.exposeInMainWorld("electronAPI", {
+  openVideoDialog: () => ipcRenderer.invoke("open-video-dialog"),
+  getFileStats: (filePath: string) =>
+    ipcRenderer.invoke("get-file-stats", filePath),
+  processVideo: async (filePath: string, params: any) => {
+    try {
+      const result = await ipcRenderer.invoke("process-video-request", {
+        filePath: filePath,
+        requestParams: params,
+      });
+
+      return result;
+    } catch (error) {
+      throw error;
+    }
+  },
+} as ElectronAPI);

--- a/client_desktop_app/src/renderer.ts
+++ b/client_desktop_app/src/renderer.ts
@@ -1,0 +1,414 @@
+interface ProcessingParams {
+  action: number;
+  resolution?: string;
+  aspect_ratio?: string;
+  startseconds?: number;
+  endseconds?: number;
+  extension?: string;
+}
+
+interface SelectedFile {
+  path: string;
+  name: string;
+  size: number;
+}
+
+class VideoProcessorUI {
+  private selectedFile: SelectedFile | null = null;
+  private selectedOperation: string | null = null;
+  private processingParams: ProcessingParams | null = null;
+
+  constructor() {
+    this.initializeEventListeners();
+  }
+
+  private initializeEventListeners(): void {
+    this.setupFileUpload();
+
+    // 処理モードカードを有効にしてからの処理
+    this.setupOperationSelection();
+
+    //　選択された処理モードに応じてsetting-groupを表示し、実行ボタンを有効にした後の処理
+    this.setupExecuteButton();
+  }
+
+  private async setupFileUpload(): Promise<void> {
+    const uploadArea = document.getElementById("uploadArea") as HTMLDivElement;
+    const fileInfo = document.getElementById("fileInfo") as HTMLDivElement;
+    const fileName = document.getElementById(
+      "fileName",
+    ) as HTMLParagraphElement;
+
+    uploadArea.addEventListener("click", async () => {
+      try {
+        const filePath = await (window as any).electronAPI.openVideoDialog();
+
+        if (filePath) {
+          console.log("選択されたファイルパス：", filePath);
+
+          const fileStats = await (window as any).electronAPI.getFileStats(
+            filePath,
+          );
+
+          if (!fileStats) {
+            alert("ファイル情報を取得できませんでした");
+            return;
+          }
+
+          const maxSize = Math.pow(2, 40);
+          if (fileStats.size > maxSize) {
+            alert("処理対象の動画ファイルは1TB以下です。");
+            return;
+          }
+
+          const selectedFileName = filePath.split(/[\\/]/).pop() || "Unknown";
+
+          this.selectedFile = {
+            path: filePath,
+            name: selectedFileName,
+            size: fileStats.size,
+          };
+
+          fileName.textContent = `${selectedFileName} (${this.formatFileSize(fileStats.size)})`;
+
+          fileInfo.classList.remove("hidden");
+
+          this.enableOperationSelection();
+        } else {
+          console.log("ファイルが選択されていません");
+        }
+      } catch (error) {
+        console.error("ファイルが選択中のエラー：", error);
+      }
+    });
+  }
+
+  // handleFileSelection内で使用
+  private formatFileSize(bytes: number): string {
+    const sizes = ["Bytes", "KB", "MB", "GB", "TB"];
+    // 本当は1024をベースとしたlogを実行したいが、log_n(x) = log(x) / log (n)という数学プロパティを利用する
+    const i = Math.floor(Math.log(bytes) / Math.log(1024));
+    return parseFloat((bytes / Math.pow(1024, i)).toFixed(2)) + " " + sizes[i];
+  }
+
+  // handleFileSelection内で使用
+  private enableOperationSelection(): void {
+    const operationCards = document.querySelectorAll(".operation-card");
+    operationCards.forEach((card) => {
+      // 処理モードカードからdisabledプロパティを削除する
+      card.classList.remove("disabled");
+    });
+  }
+
+  private setupOperationSelection(): void {
+    const operationCards = document.querySelectorAll(".operation-card");
+    const settingsSection = document.getElementById(
+      "settingsSection",
+    ) as HTMLElement;
+
+    operationCards.forEach((card) => {
+      card.addEventListener("click", () => {
+        if (!this.selectedFile) {
+          alert("まず動画ファイルを選択してください");
+          return;
+        }
+
+        // クリックを感知したら一回全てのカードのselectedプロパティを削除し、このカードには追加する
+        operationCards.forEach((c) => c.classList.remove("selected"));
+        card.classList.add("selected");
+
+        // selectedOperationをセットする（compress, resolution, aspect, audio, gif）
+        this.selectedOperation = card.getAttribute("data-operation")!;
+
+        // セッティングセクションを表示する
+        settingsSection.classList.remove("hidden");
+
+        // 選択された処理モードに応じてsetting-groupを表示する
+        this.showRelevantSettings(this.selectedOperation);
+
+        // 実行ボタンを有効にする
+        this.updateExecuteButton();
+      });
+    });
+  }
+
+  // setupOperationSelection内で使用
+  private showRelevantSettings(operation: string): void {
+    // settings-section内にあるsetting-group divを隠す
+    const settingGroups = document.querySelectorAll(".setting-group");
+    settingGroups.forEach((group) => group.classList.add("hidden"));
+
+    // 選択された処理モードに応じてsetting-groupをidを仕様し表示する
+    switch (operation) {
+      case "resolution":
+        document
+          .getElementById("resolutionSettings")
+          ?.classList.remove("hidden");
+        break;
+      case "aspect":
+        document.getElementById("aspectSettings")?.classList.remove("hidden");
+        break;
+      case "gif":
+        document.getElementById("gifSettings")?.classList.remove("hidden");
+        break;
+    }
+
+    document.getElementById("outputSettings")?.classList.remove("hidden");
+  }
+
+  // setupOperationSelection内で使用
+  private updateExecuteButton(): void {
+    const executeBtn = document.getElementById(
+      "executeBtn",
+    ) as HTMLButtonElement;
+    // ファイルがセットされモードを選択されている場合クリックできるにする
+    if (this.selectedFile && this.selectedOperation) {
+      executeBtn.disabled = false;
+      executeBtn.textContent = "🚀 変換を実行";
+    }
+  }
+
+  private setupExecuteButton(): void {
+    const executeBtn = document.getElementById(
+      "executeBtn",
+    ) as HTMLButtonElement;
+
+    executeBtn.addEventListener("click", async () => {
+      if (!this.selectedFile || !this.selectedOperation) {
+        alert("ファイルと操作を選択してください");
+        return;
+      }
+
+      // パラメターを取得
+      this.processingParams = this.collectProcessingParams();
+
+      if (!this.processingParams) {
+        return; // Validation failed
+      }
+
+      console.log("パラメターを送信:", this.processingParams);
+      console.log("選択されたファイル:", this.selectedFile);
+
+      // プログレスを表示
+      this.showProgressSection();
+
+      try {
+        // main.tsに対してpreload.tsのAPIを通じて処理を依頼する
+        const result = await (window as any).electronAPI.processVideo(
+          this.selectedFile.path,
+          this.processingParams,
+        );
+
+        console.log("レスポンスを受信:", result);
+        this.handleProcessingSuccess(result);
+      } catch (error) {
+        console.error("プロセス中エラー:", error);
+        this.handleProcessingError(error);
+      }
+    });
+  }
+
+  private collectProcessingParams(): ProcessingParams | null {
+    const action = this.getActionNumber(this.selectedOperation!);
+    const params: ProcessingParams = {
+      action: action,
+    };
+
+    switch (this.selectedOperation) {
+      case "compress":
+        break;
+
+      case "resolution":
+        const resolutionSelect = document.getElementById(
+          "resolutionSelect",
+        ) as HTMLSelectElement;
+        params.resolution = resolutionSelect.value;
+        break;
+
+      case "aspect":
+        const aspectSelect = document.getElementById(
+          "aspectRatio",
+        ) as HTMLSelectElement;
+        params.aspect_ratio = aspectSelect.value;
+        break;
+
+      case "audio":
+        break;
+
+      case "gif":
+        const startTime = (
+          document.getElementById("startTime") as HTMLInputElement
+        ).value;
+        const endTime = (document.getElementById("endTime") as HTMLInputElement)
+          .value;
+        const format = (
+          document.getElementById("outputFormat") as HTMLSelectElement
+        ).value;
+
+        if (!startTime || !endTime) {
+          alert("開始時間と終了時間を入力してください");
+          return null;
+        }
+
+        params.startseconds = this.timeToSeconds(startTime);
+        params.endseconds = this.timeToSeconds(endTime);
+        params.extension = format;
+
+        if (params.startseconds >= params.endseconds) {
+          alert("終了時刻は開始時刻より後にしてください");
+          return null;
+        }
+        break;
+    }
+
+    return params;
+  }
+
+  private getActionNumber(operation: string): number {
+    // Mapを使用し処理モードに応じてnumberを返す
+    const actionMap: { [key: string]: number } = {
+      compress: 1,
+      resolution: 2,
+      aspect: 3,
+      audio: 4,
+      gif: 5,
+    };
+    return actionMap[operation];
+  }
+
+  private timeToSeconds(timeStr: string): number {
+    const parts = timeStr.split(":").map(Number);
+    if (parts.length === 2) {
+      return parts[0] * 60 + parts[1];
+    } else if (parts.length === 3) {
+      return parts[0] * 3600 + parts[1] * 60 + parts[2];
+    }
+    return 0;
+  }
+
+  private showProgressSection(): void {
+    // 他のセクションを全て隠す
+    document.querySelector(".upload-section")?.classList.add("hidden");
+    document.querySelector(".operation-section")?.classList.add("hidden");
+    document.querySelector(".settings-section")?.classList.add("hidden");
+    document.querySelector(".execute-section")?.classList.add("hidden");
+
+    // プログレスセクションを表示する
+    const progressSection = document.getElementById("progressSection");
+    progressSection?.classList.remove("hidden");
+
+    // animateProgressを呼び出しプロクレスを開始する
+    this.animateProgress();
+  }
+
+  private animateProgress(): void {
+    const progressFill = document.getElementById("progressFill") as HTMLElement;
+    const progressText = document.getElementById("progressText") as HTMLElement;
+
+    let progress = 0;
+    const interval = setInterval(() => {
+      progress += Math.random() * 10;
+      if (progress > 90) progress = 90;
+
+      progressFill.style.width = `${progress}%`;
+      progressText.textContent = `処理中... ${Math.round(progress)}%`;
+    }, 500);
+
+    // 後でインターバルをを削除するようにIDをセットする
+    (this as any).progressInterval = interval;
+  }
+
+  private handleProcessingSuccess(result: any): void {
+    // Complete progress
+    if ((this as any).progressInterval) {
+      clearInterval((this as any).progressInterval);
+    }
+
+    const progressFill = document.getElementById("progressFill") as HTMLElement;
+    const progressText = document.getElementById("progressText") as HTMLElement;
+    progressFill.style.width = "100%";
+    progressText.textContent = "処理完了！";
+
+    // Show result section after a brief delay
+    setTimeout(() => {
+      this.showResultSection(result);
+    }, 1000);
+  }
+
+  private handleProcessingError(error: any): void {
+    // Clear progress animation
+    if ((this as any).progressInterval) {
+      clearInterval((this as any).progressInterval);
+    }
+
+    console.error("Processing error:", error);
+    alert(`処理中にエラーが発生しました: ${error.message || error}`);
+
+    // Reset UI
+    this.resetUI();
+  }
+
+  private showResultSection(result: any): void {
+    const progressSection = document.getElementById("progressSection");
+    const resultSection = document.getElementById("resultSection");
+    const resultMessage = document.getElementById("resultMessage");
+
+    progressSection?.classList.add("hidden");
+    resultSection?.classList.remove("hidden");
+
+    if (resultMessage) {
+      resultMessage.textContent = `変換が完了しました！ファイル: ${result.filename || "処理済みファイル"}`;
+    }
+
+    // Setup download button
+    this.setupDownloadButton(result);
+  }
+
+  private setupDownloadButton(result: any): void {
+    const downloadBtn = document.getElementById("downloadBtn");
+    downloadBtn?.addEventListener("click", () => {
+      // This will be handled by the main process
+      (window as any).electronAPI.downloadFile(result);
+    });
+  }
+
+  private resetUI(): void {
+    // Show original sections
+    document.querySelector(".upload-section")?.classList.remove("hidden");
+    document.querySelector(".operation-section")?.classList.remove("hidden");
+    document.querySelector(".execute-section")?.classList.remove("hidden");
+
+    // Hide progress and result sections
+    document.getElementById("progressSection")?.classList.add("hidden");
+    document.getElementById("resultSection")?.classList.add("hidden");
+  }
+}
+
+// Initialize the UI when the DOM is loaded
+document.addEventListener("DOMContentLoaded", () => {
+  new VideoProcessorUI();
+});
+
+// Add CSS for selected state and drag-over effect
+const style = document.createElement("style");
+style.textContent = `
+  .operation-card.selected {
+    border: 2px solid #007bff;
+    background-color: #e3f2fd;
+  }
+
+  .upload-area.drag-over {
+    border-color: #007bff;
+    background-color: #f0f8ff;
+  }
+
+  .operation-card.disabled {
+    opacity: 0.5;
+    pointer-events: none;
+  }
+
+  .hidden {
+    display: none !important;
+  }
+`;
+document.head.appendChild(style);


### PR DESCRIPTION
# 概要
Electron.jsクライアントからサーバーに対して処理を依頼しダウンロードできる機能を追加

# コンソールトアウトプット
## サーバー
```
処理済みファイル（963332バイト）を送信中
処理済みファイルの送信完了
ファイル {パスを含んだファイル名} を削除しました
ファイル {パスを含んだファイル名} を削除しました
コネクションを閉じます
```

# 結果
全ての処理モードの正常系で動作確認済み
<img width="196" height="107" alt="Screenshot 2025-08-02 at 22 12 12" src="https://github.com/user-attachments/assets/69a29f3c-1c50-441c-bd82-8ba236650387" />